### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 A Model Context Protocol (MCP) server that provides read-only access to jrnl (command-line journal) entries.
 
+<a href="https://glama.ai/mcp/servers/@yostos/jrnl-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@yostos/jrnl-mcp/badge" alt="jrnl Server MCP server" />
+</a>
+
 ## Prerequisites
 
 - Node.js 18 or higher


### PR DESCRIPTION
This PR adds a badge for the [jrnl MCP Server](https://glama.ai/mcp/servers/@yostos/jrnl-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@yostos/jrnl-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@yostos/jrnl-mcp/badge" alt="jrnl Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.