### PR TITLE
fix: Correct jrnl YAML config in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,8 +32,23 @@ jobs:
       - name: Setup jrnl config
         run: |
           mkdir -p ~/.config/jrnl
-          echo '{"journals": {"default": {"journal": "/tmp/test.jrnl"}}, "version": "v4"}' > ~/.config/jrnl/jrnl.yaml
-          echo "2024-01-01 10:00 Test entry @test" > /tmp/test.jrnl
+          cat > ~/.config/jrnl/jrnl.yaml << 'YAML'
+          default_hour: 9
+          default_minute: 0
+          editor: ""
+          encrypt: false
+          highlight: true
+          indent_character: "|"
+          linewrap: 79
+          tagsymbols: "@"
+          template: false
+          timeformat: "%F %r"
+          version: v4.2
+          journals:
+            default:
+              journal: /tmp/test.jrnl
+          YAML
+          echo "[2024-01-01 10:00] Test entry @test" > /tmp/test.jrnl
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

Fix jrnl configuration in CI workflow.

### Changes
- Use proper YAML format instead of JSON for jrnl.yaml
- Fix journal entry format with timestamp brackets `[2024-01-01 10:00]`

### Related
- Fixes v1.0.1 release CI failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)