### PR TITLE
ci: Add NPM_TOKEN for npm publish authentication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,3 +31,5 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `NODE_AUTH_TOKEN` environment variable to npm publish step
- Uses `NPM_TOKEN` secret for authentication

## Required
Before merging, add `NPM_TOKEN` secret to GitHub repository:
1. npm → Access Tokens → Generate New Token (Granular Access Token)
2. GitHub → Settings → Secrets → New repository secret → `NPM_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)